### PR TITLE
Replace Node-fetch w/ Axios

### DIFF
--- a/functions/authenticate.js
+++ b/functions/authenticate.js
@@ -1,4 +1,4 @@
-const fetch = require('node-fetch');
+const axios = require('axios').default;
 const cookie = require('cookie');
 
 exports.handler = async (event) => {
@@ -13,13 +13,14 @@ exports.handler = async (event) => {
     params.append('redirect_uri', process.env.STACK_REDIRECT_URI);
 
     try {
-        const response = await fetch(endpoint, {
-            method: 'POST',
+        const response = await axios({
+            method: 'post',
+            url: endpoint,
             headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-            body: params
+            data: params
         });
 
-        if(!response.ok) {
+        if(response.statusText !== 'OK') {
             console.error('Auth response error', response);
             return {
                 statusCode: 400,
@@ -27,7 +28,7 @@ exports.handler = async (event) => {
             };
         }
 
-        const responseJson = await response.json();
+        const responseJson = response.data;
         console.log('Auth response', responseJson);
         
         // The response can return a 200 success but still have an error message

--- a/functions/fetch-bookmarks.js
+++ b/functions/fetch-bookmarks.js
@@ -1,4 +1,4 @@
-const fetch = require('node-fetch');
+const axios = require('axios').default;
 const cookie = require('cookie');
 
 exports.handler = async (event) => {
@@ -27,10 +27,10 @@ exports.handler = async (event) => {
     const endpoint = `https://api.stackexchange.com/2.2/me/favorites?${params}`;
     
     try {
-        const response = await fetch(endpoint);
-        const responseJson = await response.json();
+        const response = await axios(endpoint);
+        const responseJson = response.data;
 
-        if(!response.ok) {
+        if(response.statusText !== 'OK') {
             console.error('Favorites response error', responseJson);
             return {
                 statusCode: responseJson.error_id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,6 +180,14 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
+    "axios": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "requires": {
+        "follow-redirects": "^1.14.7"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -878,6 +886,11 @@
         "semver-regex": "^2.0.0"
       }
     },
+    "follow-redirects": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -1474,14 +1487,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -2307,11 +2312,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
     "trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -2372,20 +2372,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "axios": "^0.25.0",
     "cookie": "^0.4.1",
     "milligram": "^1.4.1",
-    "node-fetch": "^2.6.7",
     "normalize.css": "^8.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Node-fetch no longer supports commonjs 'require()' in favor of module 'import'. Axios provides the same functionality with minimal changes to my code.